### PR TITLE
Fixed Bug: Username = null when returning to sectionMain

### DIFF
--- a/app/src/main/java/com/example/clubdeportivo/SessionManager.kt
+++ b/app/src/main/java/com/example/clubdeportivo/SessionManager.kt
@@ -1,0 +1,7 @@
+package com.example.clubdeportivo
+
+import com.example.clubdeportivo.entidades.User
+
+object SessionManager {
+    var currentUser: User? = null
+}

--- a/app/src/main/java/com/example/clubdeportivo/sectionMain.kt
+++ b/app/src/main/java/com/example/clubdeportivo/sectionMain.kt
@@ -22,7 +22,7 @@ class sectionMain : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_section_main)
-        val usuario = intent.getSerializableExtra("user") as? User
+        val usuario = SessionManager.currentUser
         val userDetails = findViewById<TextView>(R.id.userDetails)
         userDetails.text = usuario?.nombre.toString() + " (" + usuario?.rol.toString() + ")"
         drawerLayout = findViewById(R.id.main)


### PR DESCRIPTION
Se soluciono comportamiento donde el usuario y rol se volvían null al regresar a la pantalla principal.
| First Time | Returning |
|----------|----------|
| ![image](https://github.com/user-attachments/assets/4d7fd6ab-b088-4e5a-9359-2e2b5a0e2b50) | ![image](https://github.com/user-attachments/assets/a36f05d3-3f0a-418b-bd69-1009effd8165) |

Como solución se creo la clase SessionManager, la cual mantiene datos en memoria durante la sesión. 